### PR TITLE
Update datasource.go

### DIFF
--- a/maxmarkusprogram-prtg-datasource/pkg/plugin/datasource.go
+++ b/maxmarkusprogram-prtg-datasource/pkg/plugin/datasource.go
@@ -244,7 +244,8 @@ func parsePRTGDateTime(datetime string) (time.Time, string, error) {
 
 	// PRTG sends times in local timezone, so we need to handle both formats
 	layouts := []string{
-		"02.01.2006 15:04:05",
+		"02.01.2006 15:04:05", //Case when PRTG send time in this format or
+		"2006-01-02 15:04:05", //case when PRTG send in this format
 		time.RFC3339,
 	}
 


### PR DESCRIPTION
Add second time layout from PRTG, when have parse time Error from PRTG like: _error="parsing time \"2025-05-07 17:28:42\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \" 17:28:42\" as \"T\""_